### PR TITLE
basic filter support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+AwsSsh.egg-info

--- a/awsssh/awsssh.py
+++ b/awsssh/awsssh.py
@@ -54,14 +54,14 @@ def grab_ec2_instances(keys, region=None, *args, **kwargs):
     reservations = conn.get_all_instances(filters=filters)
 
     hostname_key = kwargs.get('hostname_key', 'public_dns_name')
-    hostname_format = kwargs.get('hostname_format')
+    host_format = kwargs.get('host_format')
 
     ec2_instances = {}
     for instance in reservations:
         instance = instance.instances[0]
         try:
-            if hostname_format:
-                host_identifier = hostname_format.format(**instance.__dict__)
+            if host_format:
+                host_identifier = host_format.format(**instance.__dict__)
             else:
                 host_identifier = instance.tags['Name']
             ec2_instances[host_identifier] = {'HostName': getattr(instance, hostname_key)}

--- a/awsssh/awsssh.py
+++ b/awsssh/awsssh.py
@@ -57,16 +57,16 @@ def grab_ec2_instances(keys, region=None, *args, **kwargs):
     host_format = kwargs.get('host_format')
 
     ec2_instances = {}
-    for instance in reservations:
-        instance = instance.instances[0]
-        try:
-            if host_format:
-                host_identifier = host_format.format(**instance.__dict__)
-            else:
-                host_identifier = instance.tags['Name']
-            ec2_instances[host_identifier] = {'HostName': getattr(instance, hostname_key)}
-        except Exception:
-            sys.stderr.write('Error retrieving %s' % instance.id)
+    for reservation in reservations:
+        for instance in reservation.instances:
+            try:
+                if host_format:
+                    host_identifier = host_format.format(**instance.__dict__)
+                else:
+                    host_identifier = instance.tags['Name']
+                ec2_instances[host_identifier] = {'HostName': getattr(instance, hostname_key)}
+            except Exception:
+                sys.stderr.write('Error retrieving %s' % instance.id)
     return ec2_instances
 
 
@@ -83,8 +83,8 @@ def generate_single_host(instance, instance_dict, env_configs=None):
             configs.append(CONFIG_TMP.format(key=key, value=value))
 
     return HOST_TMP.format(
-        hostname = instance,
-        configs = "\n".join(configs))
+        hostname=instance,
+        configs="\n".join(configs))
 
 
 def read_raw_config():


### PR DESCRIPTION
Every EC2 instances does not necessarily have a Name tag to use as the SSH config's Host value. This PR provides the ability to specify which attribute of the EC2 instance to use as the Host value by way of a host_format string. This string will be formatted by passing the EC2 instance's `__dict__` property which means that any properties of the instance can be used in the host_format. For example:

``` python
fake_ec2__dict__ = {
    "id": "i-630c956c"
}

# Passed from config as the host_format property
host_format = "project-foo-{id}"

host_format.format(**fake_ec2_dict)
# > "project-foo-i-630c956c"
# Will be used like so
# Host project-foo-i-630c956c
#    HostName ...
```

Instances may not have a public_dns_name, so you can now specify which instance property to use to set the HostName config with the `hostname_key` property in the config.

This PR also provides the ability to provide arbitrary filters to be passed to boto's `get_all_instances` commands from the config file. These are specific to each config entry and are passed by the `filter` property of the config entries.
